### PR TITLE
Update harextract.html

### DIFF
--- a/harextract.html
+++ b/harextract.html
@@ -183,6 +183,9 @@ function loadHARJSON (har) {
             console.log(`harextract: skipped ${harent.name} (${id}): ${harent.error}`);
             skipped.push(harent);
         } else {
+            if ('' == harent.name){
+				harent.name = 'unnamed file';
+			}
             commonpath = fullpath.slice(0, [...fullpath,null].findIndex((p, n) => p !== (commonpath||fullpath)[n])); // ;)
             harents.push(harent); // note: we can now guarantee that if harents has items, commonpath is set.
         }


### PR DESCRIPTION
In some cases tables contains tags <a> with no text, so such files are hard to save.
![image](https://github.com/tikhon-kozyrev/harextract/assets/124362526/72838980-fb26-4d91-b53e-e167e0a3d71c)

This patch makes such table rows downloadable
![image](https://github.com/tikhon-kozyrev/harextract/assets/124362526/bfa8833c-27bc-4652-9557-cbf84fb935bc)
